### PR TITLE
Add Room predictions store

### DIFF
--- a/app/src/main/java/be/buithg/etghaifgte/data/local/dao/PredictionDao.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/data/local/dao/PredictionDao.kt
@@ -1,0 +1,16 @@
+package be.buithg.etghaifgte.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import be.buithg.etghaifgte.data.local.entity.PredictionEntity
+
+@Dao
+interface PredictionDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(prediction: PredictionEntity)
+
+    @Query("SELECT * FROM predictions ORDER BY id DESC")
+    suspend fun getAll(): List<PredictionEntity>
+}

--- a/app/src/main/java/be/buithg/etghaifgte/data/local/database/AppDatabase.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/data/local/database/AppDatabase.kt
@@ -1,0 +1,11 @@
+package be.buithg.etghaifgte.data.local.database
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import be.buithg.etghaifgte.data.local.dao.PredictionDao
+import be.buithg.etghaifgte.data.local.entity.PredictionEntity
+
+@Database(entities = [PredictionEntity::class], version = 1, exportSchema = false)
+abstract class AppDatabase : RoomDatabase() {
+    abstract fun predictionDao(): PredictionDao
+}

--- a/app/src/main/java/be/buithg/etghaifgte/data/local/entity/PredictionEntity.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/data/local/entity/PredictionEntity.kt
@@ -1,0 +1,17 @@
+package be.buithg.etghaifgte.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "predictions")
+data class PredictionEntity(
+    @PrimaryKey(autoGenerate = true) val id: Int = 0,
+    val teamA: String,
+    val teamB: String,
+    val dateTime: String,
+    val pick: String,
+    val predicted: Int,
+    val corrects: Int,
+    val upcoming: Int,
+    val wonMatches: Int
+)

--- a/app/src/main/java/be/buithg/etghaifgte/data/local/repository/PredictionRepositoryImpl.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/data/local/repository/PredictionRepositoryImpl.kt
@@ -1,0 +1,18 @@
+package be.buithg.etghaifgte.data.local.repository
+
+import be.buithg.etghaifgte.data.local.dao.PredictionDao
+import be.buithg.etghaifgte.data.local.entity.PredictionEntity
+import be.buithg.etghaifgte.domain.repository.PredictionRepository
+import javax.inject.Inject
+
+class PredictionRepositoryImpl @Inject constructor(
+    private val dao: PredictionDao
+) : PredictionRepository {
+    override suspend fun addPrediction(prediction: PredictionEntity) {
+        dao.insert(prediction)
+    }
+
+    override suspend fun getPredictions(): List<PredictionEntity> {
+        return dao.getAll()
+    }
+}

--- a/app/src/main/java/be/buithg/etghaifgte/di/DatabaseModule.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/di/DatabaseModule.kt
@@ -1,0 +1,25 @@
+package be.buithg.etghaifgte.di
+
+import android.content.Context
+import androidx.room.Room
+import be.buithg.etghaifgte.data.local.dao.PredictionDao
+import be.buithg.etghaifgte.data.local.database.AppDatabase
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DatabaseModule {
+
+    @Provides
+    @Singleton
+    fun provideDatabase(@ApplicationContext context: Context): AppDatabase =
+        Room.databaseBuilder(context, AppDatabase::class.java, "app_db").build()
+
+    @Provides
+    fun providePredictionDao(db: AppDatabase): PredictionDao = db.predictionDao()
+}

--- a/app/src/main/java/be/buithg/etghaifgte/di/RepositoryModule.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/di/RepositoryModule.kt
@@ -2,6 +2,8 @@ package be.buithg.etghaifgte.di
 
 import be.buithg.etghaifgte.data.repository.MatchRepositoryImpl
 import be.buithg.etghaifgte.domain.repository.MatchRepository
+import be.buithg.etghaifgte.data.local.repository.PredictionRepositoryImpl
+import be.buithg.etghaifgte.domain.repository.PredictionRepository
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -17,5 +19,11 @@ abstract class RepositoryModule {
     abstract fun bindMatchRepository(
         impl: MatchRepositoryImpl
     ): MatchRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindPredictionRepository(
+        impl: PredictionRepositoryImpl
+    ): PredictionRepository
 }
 

--- a/app/src/main/java/be/buithg/etghaifgte/domain/repository/PredictionRepository.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/domain/repository/PredictionRepository.kt
@@ -1,0 +1,8 @@
+package be.buithg.etghaifgte.domain.repository
+
+import be.buithg.etghaifgte.data.local.entity.PredictionEntity
+
+interface PredictionRepository {
+    suspend fun addPrediction(prediction: PredictionEntity)
+    suspend fun getPredictions(): List<PredictionEntity>
+}

--- a/app/src/main/java/be/buithg/etghaifgte/domain/usecase/AddPredictionUseCase.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/domain/usecase/AddPredictionUseCase.kt
@@ -1,0 +1,13 @@
+package be.buithg.etghaifgte.domain.usecase
+
+import be.buithg.etghaifgte.data.local.entity.PredictionEntity
+import be.buithg.etghaifgte.domain.repository.PredictionRepository
+import javax.inject.Inject
+
+class AddPredictionUseCase @Inject constructor(
+    private val repository: PredictionRepository
+) {
+    suspend operator fun invoke(prediction: PredictionEntity) {
+        repository.addPrediction(prediction)
+    }
+}

--- a/app/src/main/java/be/buithg/etghaifgte/domain/usecase/GetPredictionsUseCase.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/domain/usecase/GetPredictionsUseCase.kt
@@ -1,0 +1,13 @@
+package be.buithg.etghaifgte.domain.usecase
+
+import be.buithg.etghaifgte.data.local.entity.PredictionEntity
+import be.buithg.etghaifgte.domain.repository.PredictionRepository
+import javax.inject.Inject
+
+class GetPredictionsUseCase @Inject constructor(
+    private val repository: PredictionRepository
+) {
+    suspend operator fun invoke(): List<PredictionEntity> {
+        return repository.getPredictions()
+    }
+}

--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/adapters/PredictionsAdapter.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/adapters/PredictionsAdapter.kt
@@ -1,0 +1,37 @@
+package be.buithg.etghaifgte.presentation.ui.adapters
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import be.buithg.etghaifgte.data.local.entity.PredictionEntity
+import be.buithg.etghaifgte.databinding.ItemHistoryPredictionBinding
+
+class PredictionsAdapter(
+    private val items: List<PredictionEntity>
+) : RecyclerView.Adapter<PredictionsAdapter.PredictionViewHolder>() {
+
+    inner class PredictionViewHolder(
+        private val binding: ItemHistoryPredictionBinding
+    ) : RecyclerView.ViewHolder(binding.root) {
+        fun bind(item: PredictionEntity) {
+            binding.textTime.text = item.dateTime
+            binding.textDate.text = ""
+            binding.textTeams.text = "${item.teamA}  ${item.teamB}"
+            binding.textPick.text = "Pick: ${item.pick}"
+            binding.textResult.text = ""
+            binding.btnViewDetails.text = ""
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PredictionViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        val binding = ItemHistoryPredictionBinding.inflate(inflater, parent, false)
+        return PredictionViewHolder(binding)
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    override fun onBindViewHolder(holder: PredictionViewHolder, position: Int) {
+        holder.bind(items[position])
+    }
+}

--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/MatchDetailFragment.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/MatchDetailFragment.kt
@@ -13,10 +13,15 @@ import be.buithg.etghaifgte.databinding.DialogPredictWinnerBinding
 import be.buithg.etghaifgte.databinding.FragmentMatchDetailBinding
 import be.buithg.etghaifgte.domain.models.Data
 import androidx.core.os.bundleOf
+import androidx.fragment.app.viewModels
+import be.buithg.etghaifgte.data.local.entity.PredictionEntity
+import be.buithg.etghaifgte.presentation.viewmodel.PredictionsViewModel
+import dagger.hilt.android.AndroidEntryPoint
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
+@AndroidEntryPoint
 class MatchDetailFragment : Fragment() {
 
     companion object {
@@ -29,6 +34,8 @@ class MatchDetailFragment : Fragment() {
     }
 
     private lateinit var binding: FragmentMatchDetailBinding
+    private val predictionsViewModel: PredictionsViewModel by viewModels()
+    private var selectedTeam: String? = null
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -51,12 +58,30 @@ class MatchDetailFragment : Fragment() {
 
             dialog.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
 
+            val team1 = match?.teamInfo?.getOrNull(0)?.shortname ?: match?.teams?.getOrNull(0) ?: ""
+            val team2 = match?.teamInfo?.getOrNull(1)?.shortname ?: match?.teams?.getOrNull(1) ?: ""
+            dialogBinding.teamAText.text = team1
+            dialogBinding.teamBText.text = team2
+            dialogBinding.cardTeamA.setOnClickListener { selectedTeam = team1 }
+            dialogBinding.cardTeamB.setOnClickListener { selectedTeam = team2 }
+
             dialogBinding.btnClose.setOnClickListener {
                 dialog.dismiss()
             }
 
             dialogBinding.btnSubmit.setOnClickListener {
-                // TODO: handle submit logic here
+                val pick = selectedTeam ?: return@setOnClickListener
+                val entity = PredictionEntity(
+                    teamA = team1,
+                    teamB = team2,
+                    dateTime = match?.dateTimeGMT ?: "",
+                    pick = pick,
+                    predicted = 1,
+                    corrects = 0,
+                    upcoming = 1,
+                    wonMatches = 0
+                )
+                predictionsViewModel.addPrediction(entity)
                 dialog.dismiss()
             }
 

--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/PredictionsFragment.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/PredictionsFragment.kt
@@ -6,14 +6,17 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import be.buithg.etghaifgte.R
+import androidx.fragment.app.viewModels
 import be.buithg.etghaifgte.databinding.FragmentPredictionsBinding
+import be.buithg.etghaifgte.presentation.ui.adapters.PredictionsAdapter
+import be.buithg.etghaifgte.presentation.viewmodel.PredictionsViewModel
+import dagger.hilt.android.AndroidEntryPoint
 
-
+@AndroidEntryPoint
 class PredictionsFragment : Fragment() {
 
     private lateinit var binding: FragmentPredictionsBinding
-
-
+    private val viewModel: PredictionsViewModel by viewModels()
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
@@ -24,5 +27,11 @@ class PredictionsFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        viewModel.predictions.observe(viewLifecycleOwner) {
+            binding.recyclerView.apply {
+                adapter = PredictionsAdapter(it)
+            }
+        }
+        viewModel.loadPredictions()
     }
 }

--- a/app/src/main/java/be/buithg/etghaifgte/presentation/viewmodel/PredictionsViewModel.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/viewmodel/PredictionsViewModel.kt
@@ -1,0 +1,35 @@
+package be.buithg.etghaifgte.presentation.viewmodel
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import be.buithg.etghaifgte.data.local.entity.PredictionEntity
+import be.buithg.etghaifgte.domain.usecase.AddPredictionUseCase
+import be.buithg.etghaifgte.domain.usecase.GetPredictionsUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class PredictionsViewModel @Inject constructor(
+    private val addPredictionUseCase: AddPredictionUseCase,
+    private val getPredictionsUseCase: GetPredictionsUseCase
+) : ViewModel() {
+
+    private val _predictions = MutableLiveData<List<PredictionEntity>>()
+    val predictions: LiveData<List<PredictionEntity>> = _predictions
+
+    fun loadPredictions() {
+        viewModelScope.launch {
+            _predictions.value = getPredictionsUseCase()
+        }
+    }
+
+    fun addPrediction(entity: PredictionEntity) {
+        viewModelScope.launch {
+            addPredictionUseCase(entity)
+            loadPredictions()
+        }
+    }
+}

--- a/app/src/main/res/layout/dialog_predict_winner.xml
+++ b/app/src/main/res/layout/dialog_predict_winner.xml
@@ -63,6 +63,7 @@
                     android:textSize="18sp"/>
 
                 <TextView
+                    android:id="@+id/teamAText"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="Gladiators Cricket"
@@ -100,6 +101,7 @@
                     android:textSize="18sp"/>
 
                 <TextView
+                    android:id="@+id/teamBText"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="Fairy Game"

--- a/app/src/main/res/layout/fragment_predictions.xml
+++ b/app/src/main/res/layout/fragment_predictions.xml
@@ -42,6 +42,7 @@
 
 
         <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recyclerView"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_marginHorizontal="10dp"


### PR DESCRIPTION
## Summary
- implement a Room DB for predictions
- wire up a repository and viewmodel
- record predictions from MatchDetail dialog
- display saved predictions in Predictions screen

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877c50518d4832ab970c2d3cafac87a