### PR TITLE
Add help button transitions

### DIFF
--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/AchievementsFragment.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/AchievementsFragment.kt
@@ -51,6 +51,10 @@ class AchievementsFragment : Fragment() {
             }
         })
 
+        binding.btnHelp.setOnClickListener {
+            findNavController().navigate(R.id.tutorialFragment)
+        }
+
         viewModel.predictions.observe(viewLifecycleOwner) { list ->
             updateAchievements(list)
         }

--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/BlogDetailFragment.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/BlogDetailFragment.kt
@@ -34,6 +34,10 @@ class BlogDetailFragment : Fragment() {
             }
         })
 
+        binding.btnHelp.setOnClickListener {
+            findNavController().navigate(R.id.tutorialFragment)
+        }
+
         binding.itemTitle.text = args.title
         binding.articleText.text = args.text
         binding.itemImage.setImageResource(args.imageRes)

--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/BlogFragment.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/BlogFragment.kt
@@ -253,6 +253,10 @@ your financial situation.
                 findNavController().navigate(R.id.matchScheduleFragment)
             }
         })
+
+        binding.btnHelp.setOnClickListener {
+            findNavController().navigate(R.id.tutorialFragment)
+        }
         val cardViews = listOf(
             binding.cardItem1,
             binding.cardItem2,

--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/MatchDetailFragment.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/MatchDetailFragment.kt
@@ -70,6 +70,10 @@ class MatchDetailFragment : Fragment() {
             }
         })
 
+        binding.btnHelp.setOnClickListener {
+            findNavController().navigate(R.id.tutorialFragment)
+        }
+
         val match = args.match
         bindMatch(match)
 

--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/MatchScheduleFragment.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/MatchScheduleFragment.kt
@@ -53,6 +53,10 @@ class MatchScheduleFragment : Fragment() {
             Log.e("FFFF", "No Internet connection")
         }
 
+        binding.btnHelp.setOnClickListener {
+            findNavController().navigate(R.id.tutorialFragment)
+        }
+
         viewModel.matches.observe(viewLifecycleOwner) { list ->
             allMatches = list
             filterAndDisplay(selectedBtn ?: binding.btnToday)

--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/PredictionHistoryFragment.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/PredictionHistoryFragment.kt
@@ -45,6 +45,10 @@ class PredictionHistoryFragment : Fragment() {
             }
         })
 
+        binding.btnHelp.setOnClickListener {
+            findNavController().navigate(R.id.tutorialFragment)
+        }
+
         buttons = listOf(binding.btnYesterday, binding.btnToday, binding.btnTomorrow)
 
         val filterMap = mapOf(

--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/PredictionsFragment.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/PredictionsFragment.kt
@@ -36,6 +36,10 @@ class PredictionsFragment : Fragment() {
             }
         })
 
+        binding.btnHelp.setOnClickListener {
+            findNavController().navigate(R.id.tutorialFragment)
+        }
+
         viewModel.predictions.observe(viewLifecycleOwner) {
             binding.recyclerView.apply {
                 adapter = PredictionsAdapter(it)

--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/StatsFragment.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/StatsFragment.kt
@@ -84,6 +84,10 @@ class StatsFragment : Fragment(R.layout.fragment_stats) {
                 findNavController().navigate(R.id.matchScheduleFragment)
             }
         })
+
+        binding.btnHelp.setOnClickListener {
+            findNavController().navigate(R.id.tutorialFragment)
+        }
         viewModel.predictions.observe(viewLifecycleOwner) { list ->
             updateSummary(list)
             setupAccuracyChart(list)

--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/TutorialFragment.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/TutorialFragment.kt
@@ -30,6 +30,10 @@ class TutorialFragment : Fragment() {
                 findNavController().navigateUp()
             }
         })
+
+        binding.btnHelp.setOnClickListener {
+            findNavController().navigate(R.id.tutorialFragment)
+        }
     }
 
 }

--- a/app/src/main/res/navigation/secondgraph.xml
+++ b/app/src/main/res/navigation/secondgraph.xml
@@ -62,4 +62,10 @@
             android:name="match"
             app:argType="be.buithg.etghaifgte.domain.models.Data" />
     </fragment>
+
+    <fragment
+        android:id="@+id/tutorialFragment"
+        android:name="be.buithg.etghaifgte.presentation.ui.fragments.main.TutorialFragment"
+        android:label="fragment_tutorial"
+        tools:layout="@layout/fragment_tutorial" />
 </navigation>


### PR DESCRIPTION
## Summary
- navigate to `tutorialFragment` when `btnHelp` is clicked across fragments
- register `tutorialFragment` in the navigation graph

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687892c43ec4832a891dc325320de7c8