### PR TITLE
Add empty state messages

### DIFF
--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/MatchScheduleFragment.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/MatchScheduleFragment.kt
@@ -22,6 +22,7 @@ import androidx.navigation.fragment.findNavController
 import be.buithg.etghaifgte.presentation.ui.fragments.main.MatchScheduleFragmentDirections
 import be.buithg.etghaifgte.presentation.viewmodel.PredictionsViewModel
 import be.buithg.etghaifgte.utils.NetworkUtils.isInternetAvailable
+import androidx.core.view.isVisible
 
 import java.time.LocalDate
 
@@ -137,7 +138,7 @@ class MatchScheduleFragment : Fragment() {
                 MatchScheduleFragmentDirections.actionMatchScheduleFragmentToMatchDetailFragment(match)
             findNavController().navigate(action)
         }
-
         binding.recyclerMatcher.adapter = adapter
+        binding.tvEmptyMatches.isVisible = filtered.isEmpty()
     }
 }

--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/PredictionHistoryFragment.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/PredictionHistoryFragment.kt
@@ -11,6 +11,7 @@ import be.buithg.etghaifgte.R
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import be.buithg.etghaifgte.databinding.FragmentPredictionHistoryBinding
+import androidx.core.view.isVisible
 import be.buithg.etghaifgte.data.local.entity.PredictionEntity
 import be.buithg.etghaifgte.presentation.ui.adapters.HistoryAdapter
 import be.buithg.etghaifgte.presentation.viewmodel.PredictionsViewModel
@@ -100,6 +101,7 @@ class PredictionHistoryFragment : Fragment() {
             Filter.LOST -> allPredictions.filter { getResult(it) == "Lose" }
         }
         binding.predictionsHistoryRecyclerview.adapter = HistoryAdapter(list)
+        binding.tvEmptyHistory.isVisible = list.isEmpty()
     }
 
 }

--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/PredictionsFragment.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/PredictionsFragment.kt
@@ -10,6 +10,7 @@ import be.buithg.etghaifgte.R
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import be.buithg.etghaifgte.databinding.FragmentPredictionsBinding
+import androidx.core.view.isVisible
 import be.buithg.etghaifgte.presentation.ui.adapters.PredictionsAdapter
 import be.buithg.etghaifgte.presentation.viewmodel.PredictionsViewModel
 import dagger.hilt.android.AndroidEntryPoint
@@ -40,10 +41,9 @@ class PredictionsFragment : Fragment() {
             findNavController().navigate(R.id.tutorialFragment)
         }
 
-        viewModel.predictions.observe(viewLifecycleOwner) {
-            binding.recyclerView.apply {
-                adapter = PredictionsAdapter(it)
-            }
+        viewModel.predictions.observe(viewLifecycleOwner) { list ->
+            binding.recyclerView.adapter = PredictionsAdapter(list)
+            binding.tvEmptyPredictions.isVisible = list.isEmpty()
         }
         viewModel.loadPredictions()
     }

--- a/app/src/main/res/layout/fragment_match_schedule.xml
+++ b/app/src/main/res/layout/fragment_match_schedule.xml
@@ -323,6 +323,16 @@
                 tools:listitem="@layout/match_item"
                 android:layout_gravity="bottom"/>
 
+            <TextView
+                android:id="@+id/tvEmptyMatches"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:text="Currently there's no data"
+                android:textColor="#FFFFFF"
+                android:layout_marginTop="16dp"
+                android:visibility="gone"/>
+
         </LinearLayout>
 
     </FrameLayout>

--- a/app/src/main/res/layout/fragment_prediction_history.xml
+++ b/app/src/main/res/layout/fragment_prediction_history.xml
@@ -114,6 +114,16 @@
             tools:listitem="@layout/item_history_prediction"
             android:layout_marginBottom="10dp"/>
 
+        <TextView
+            android:id="@+id/tvEmptyHistory"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:text="Currently there's no data"
+            android:textColor="#FFFFFF"
+            android:layout_marginTop="16dp"
+            android:visibility="gone"/>
+
     </LinearLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/fragment_predictions.xml
+++ b/app/src/main/res/layout/fragment_predictions.xml
@@ -48,6 +48,16 @@
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             android:layout_marginBottom="10dp"/>
 
+        <TextView
+            android:id="@+id/tvEmptyPredictions"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:text="Currently there's no data"
+            android:textColor="#FFFFFF"
+            android:visibility="gone"
+            android:layout_marginVertical="16dp"/>
+
     </LinearLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Summary
- show empty data message in match schedule
- show empty data message in predictions history and list

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878f32bcf14832a8cd913e396513585