### PR TITLE
Add recycler view empty states

### DIFF
--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/adapters/CricketAdapter.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/adapters/CricketAdapter.kt
@@ -15,31 +15,42 @@ import java.time.format.DateTimeFormatter
 class CricketAdapter(
     private val items: ArrayList<Data>,
     private val onItemClick: (Data) -> Unit
-) : RecyclerView.Adapter<CricketAdapter.CricketViewHolder>() {
+) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
     private companion object {
         const val MAX_TEAM_LEN = 12
         const val MAX_STATUS_LEN = 15
+        const val TYPE_MATCH = 0
+        const val TYPE_EMPTY = 1
     }
 
     private val leagueColors = listOf("#D2F61D", "#F6771D", "#1DF6BC", "#D2F61D")
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CricketViewHolder {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         val inflater = LayoutInflater.from(parent.context)
-        val binding = MatchItemBinding.inflate(
-            inflater,
-            parent,
-            false
-        )
-        return CricketViewHolder(binding)
+        return if (viewType == TYPE_MATCH) {
+            val binding = MatchItemBinding.inflate(inflater, parent, false)
+            CricketViewHolder(binding)
+        } else {
+            val binding = be.buithg.etghaifgte.databinding.ItemEmptyStateBinding.inflate(
+                inflater,
+                parent,
+                false
+            )
+            EmptyViewHolder(binding)
+        }
     }
 
-    override fun getItemCount(): Int = items.size
+    override fun getItemCount(): Int = if (items.isEmpty()) 1 else items.size
 
-    override fun onBindViewHolder(holder: CricketViewHolder, position: Int) {
-        val currentitem = items[position]
-        holder.bind(currentitem, position)
-        holder.itemView.setOnClickListener { onItemClick(currentitem) }
+    override fun getItemViewType(position: Int): Int = if (items.isEmpty()) TYPE_EMPTY else TYPE_MATCH
+
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        if (holder is CricketViewHolder) {
+            val item = items[position]
+            holder.bind(item, position)
+            holder.itemView.setOnClickListener { onItemClick(item) }
+        }
     }
 
     inner class CricketViewHolder(
@@ -70,5 +81,9 @@ class CricketAdapter(
         private fun String.truncate(max: Int): String =
             if (length > max) take(max) + "…" else this
     }
-    }
+
+    inner class EmptyViewHolder(binding: be.buithg.etghaifgte.databinding.ItemEmptyStateBinding) :
+        RecyclerView.ViewHolder(binding.root)
+}
+
 

--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/adapters/HistoryAdapter.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/adapters/HistoryAdapter.kt
@@ -10,7 +10,12 @@ import java.time.format.DateTimeFormatter
 
 class HistoryAdapter(
     private val items: List<PredictionEntity>
-) : RecyclerView.Adapter<HistoryAdapter.HistoryViewHolder>() {
+) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+
+    private companion object {
+        const val TYPE_ITEM = 0
+        const val TYPE_EMPTY = 1
+    }
 
     private val timeFormatter = DateTimeFormatter.ofPattern("HH:mm")
     private val dateFormatter = DateTimeFormatter.ofPattern("dd.MM.yyyy")
@@ -39,15 +44,31 @@ class HistoryAdapter(
         }
     }
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): HistoryViewHolder {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         val inflater = LayoutInflater.from(parent.context)
-        val binding = ItemHistoryPredictionBinding.inflate(inflater, parent, false)
-        return HistoryViewHolder(binding)
+        return if (viewType == TYPE_ITEM) {
+            val binding = ItemHistoryPredictionBinding.inflate(inflater, parent, false)
+            HistoryViewHolder(binding)
+        } else {
+            val binding = be.buithg.etghaifgte.databinding.ItemEmptyStateBinding.inflate(
+                inflater,
+                parent,
+                false
+            )
+            EmptyViewHolder(binding)
+        }
     }
 
-    override fun getItemCount(): Int = items.size
+    override fun getItemCount(): Int = if (items.isEmpty()) 1 else items.size
 
-    override fun onBindViewHolder(holder: HistoryViewHolder, position: Int) {
-        holder.bind(items[position])
+    override fun getItemViewType(position: Int): Int = if (items.isEmpty()) TYPE_EMPTY else TYPE_ITEM
+
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        if (holder is HistoryViewHolder) {
+            holder.bind(items[position])
+        }
     }
+
+    inner class EmptyViewHolder(binding: be.buithg.etghaifgte.databinding.ItemEmptyStateBinding) :
+        RecyclerView.ViewHolder(binding.root)
 }

--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/adapters/PredictionsAdapter.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/adapters/PredictionsAdapter.kt
@@ -10,7 +10,12 @@ import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 class PredictionsAdapter(
     private val items: List<PredictionEntity>
-) : RecyclerView.Adapter<PredictionsAdapter.PredictionViewHolder>() {
+) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+
+    private companion object {
+        const val TYPE_ITEM = 0
+        const val TYPE_EMPTY = 1
+    }
 
     private val timeFormatter = DateTimeFormatter.ofPattern("HH:mm")
     private val dateFormatter = DateTimeFormatter.ofPattern("dd.MM.yyyy")
@@ -53,15 +58,31 @@ class PredictionsAdapter(
         }
     }
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PredictionViewHolder {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         val inflater = LayoutInflater.from(parent.context)
-        val binding = ItemPredictionBinding.inflate(inflater, parent, false)
-        return PredictionViewHolder(binding)
+        return if (viewType == TYPE_ITEM) {
+            val binding = ItemPredictionBinding.inflate(inflater, parent, false)
+            PredictionViewHolder(binding)
+        } else {
+            val binding = be.buithg.etghaifgte.databinding.ItemEmptyStateBinding.inflate(
+                inflater,
+                parent,
+                false
+            )
+            EmptyViewHolder(binding)
+        }
     }
 
-    override fun getItemCount(): Int = items.size
+    override fun getItemCount(): Int = if (items.isEmpty()) 1 else items.size
 
-    override fun onBindViewHolder(holder: PredictionViewHolder, position: Int) {
-        holder.bind(items[position])
+    override fun getItemViewType(position: Int): Int = if (items.isEmpty()) TYPE_EMPTY else TYPE_ITEM
+
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        if (holder is PredictionViewHolder) {
+            holder.bind(items[position])
+        }
     }
+
+    inner class EmptyViewHolder(binding: be.buithg.etghaifgte.databinding.ItemEmptyStateBinding) :
+        RecyclerView.ViewHolder(binding.root)
 }

--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/MatchScheduleFragment.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/MatchScheduleFragment.kt
@@ -139,6 +139,5 @@ class MatchScheduleFragment : Fragment() {
             findNavController().navigate(action)
         }
         binding.recyclerMatcher.adapter = adapter
-        binding.tvEmptyMatches.isVisible = filtered.isEmpty()
     }
 }

--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/PredictionHistoryFragment.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/PredictionHistoryFragment.kt
@@ -101,7 +101,6 @@ class PredictionHistoryFragment : Fragment() {
             Filter.LOST -> allPredictions.filter { getResult(it) == "Lose" }
         }
         binding.predictionsHistoryRecyclerview.adapter = HistoryAdapter(list)
-        binding.tvEmptyHistory.isVisible = list.isEmpty()
     }
 
 }

--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/PredictionsFragment.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/PredictionsFragment.kt
@@ -43,7 +43,6 @@ class PredictionsFragment : Fragment() {
 
         viewModel.predictions.observe(viewLifecycleOwner) { list ->
             binding.recyclerView.adapter = PredictionsAdapter(list)
-            binding.tvEmptyPredictions.isVisible = list.isEmpty()
         }
         viewModel.loadPredictions()
     }

--- a/app/src/main/res/layout/fragment_match_schedule.xml
+++ b/app/src/main/res/layout/fragment_match_schedule.xml
@@ -323,16 +323,6 @@
                 tools:listitem="@layout/match_item"
                 android:layout_gravity="bottom"/>
 
-            <TextView
-                android:id="@+id/tvEmptyMatches"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:gravity="center"
-                android:text="Currently there's no data"
-                android:textColor="#FFFFFF"
-                android:layout_marginTop="16dp"
-                android:visibility="gone"/>
-
         </LinearLayout>
 
     </FrameLayout>

--- a/app/src/main/res/layout/fragment_prediction_history.xml
+++ b/app/src/main/res/layout/fragment_prediction_history.xml
@@ -114,16 +114,6 @@
             tools:listitem="@layout/item_history_prediction"
             android:layout_marginBottom="10dp"/>
 
-        <TextView
-            android:id="@+id/tvEmptyHistory"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center"
-            android:text="Currently there's no data"
-            android:textColor="#FFFFFF"
-            android:layout_marginTop="16dp"
-            android:visibility="gone"/>
-
     </LinearLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/fragment_predictions.xml
+++ b/app/src/main/res/layout/fragment_predictions.xml
@@ -48,16 +48,6 @@
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             android:layout_marginBottom="10dp"/>
 
-        <TextView
-            android:id="@+id/tvEmptyPredictions"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center"
-            android:text="Currently there's no data"
-            android:textColor="#FFFFFF"
-            android:visibility="gone"
-            android:layout_marginVertical="16dp"/>
-
     </LinearLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_empty_state.xml
+++ b/app/src/main/res/layout/item_empty_state.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center"
+    android:padding="16dp"
+    android:text="Currently there's no data"
+    android:textColor="#FFFFFF" />


### PR DESCRIPTION
## Summary
- show placeholder item when there is no data in match schedule, predictions, and history lists
- remove previous empty text views from layouts

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878f8127744832ab8b87487ebdb7595