### PR TITLE
Fix crash on empty stats

### DIFF
--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/StatsFragment.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/StatsFragment.kt
@@ -13,6 +13,7 @@ import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import be.buithg.etghaifgte.data.local.entity.PredictionEntity
 import be.buithg.etghaifgte.presentation.viewmodel.PredictionsViewModel
+import androidx.core.view.isVisible
 import dagger.hilt.android.AndroidEntryPoint
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -89,9 +90,15 @@ class StatsFragment : Fragment(R.layout.fragment_stats) {
             findNavController().navigate(R.id.tutorialFragment)
         }
         viewModel.predictions.observe(viewLifecycleOwner) { list ->
-            updateSummary(list)
-            setupAccuracyChart(list)
-            setupLineChart(list)
+            val hasData = list.isNotEmpty()
+            binding.statsScroll.isVisible = hasData
+            binding.emptyText.isVisible = !hasData
+
+            if (hasData) {
+                updateSummary(list)
+                setupAccuracyChart(list)
+                setupLineChart(list)
+            }
         }
         viewModel.loadPredictions()
     }

--- a/app/src/main/res/layout/fragment_stats.xml
+++ b/app/src/main/res/layout/fragment_stats.xml
@@ -32,6 +32,7 @@
 
 
         <ScrollView
+            android:id="@+id/statsScroll"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:fillViewport="true">
@@ -366,6 +367,16 @@
 
 
         </ScrollView>
+
+        <TextView
+            android:id="@+id/emptyText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:padding="16dp"
+            android:text="Currently there's no data"
+            android:textColor="#FFFFFF"
+            android:visibility="gone" />
 
     </LinearLayout>
 


### PR DESCRIPTION
## Summary
- avoid crash when statistics list is empty by toggling visibility
- add `statsScroll` and `emptyText` views in stats layout for empty state message

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a322e89e8832ab4ed217f15bdf967