### PR TITLE
Add achievements to navigation

### DIFF
--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/HomeFragment.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/HomeFragment.kt
@@ -8,7 +8,6 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
-import androidx.navigation.ui.setupWithNavController
 import be.buithg.etghaifgte.R
 import be.buithg.etghaifgte.databinding.FragmentHomeBinding
 import dagger.hilt.android.AndroidEntryPoint
@@ -34,7 +33,42 @@ class HomeFragment : Fragment() {
             .findFragmentById(R.id.fragment_container_view) as NavHostFragment
         val navController: NavController = navHostFragment.navController
 
-        binding.bottomNavigationView.setupWithNavController(navController)
+        binding.bottomNav.navHome.setOnClickListener {
+            navController.navigate(R.id.matchScheduleFragment)
+        }
+        binding.bottomNav.navPredictions.setOnClickListener {
+            navController.navigate(R.id.predictionsFragment)
+        }
+        binding.bottomNav.navHistory.setOnClickListener {
+            navController.navigate(R.id.predictionHistoryFragment)
+        }
+        binding.bottomNav.navStats.setOnClickListener {
+            navController.navigate(R.id.statsFragment)
+        }
+        binding.bottomNav.navBlog.setOnClickListener {
+            navController.navigate(R.id.blogFragment)
+        }
+        binding.bottomNav.navAchievements.setOnClickListener {
+            navController.navigate(R.id.achievementsFragment)
+        }
 
+        navController.addOnDestinationChangedListener { _, destination, _ ->
+            updateSelection(destination.id)
+        }
+
+    }
+
+    private fun updateSelection(id: Int) {
+        val map = mapOf(
+            R.id.matchScheduleFragment to binding.bottomNav.navHome,
+            R.id.predictionsFragment to binding.bottomNav.navPredictions,
+            R.id.predictionHistoryFragment to binding.bottomNav.navHistory,
+            R.id.statsFragment to binding.bottomNav.navStats,
+            R.id.blogFragment to binding.bottomNav.navBlog,
+            R.id.achievementsFragment to binding.bottomNav.navAchievements,
+        )
+        map.forEach { (dest, view) ->
+            view.isSelected = dest == id
+        }
     }
 }

--- a/app/src/main/res/color/custom_nav_item_color.xml
+++ b/app/src/main/res/color/custom_nav_item_color.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/yellow" android:state_selected="true" />
+    <item android:color="@color/white" />
+</selector>

--- a/app/src/main/res/layout/custom_bottom_navigation.xml
+++ b/app/src/main/res/layout/custom_bottom_navigation.xml
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/customBottomNav"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:background="#171717"
+    android:paddingTop="10dp">
+
+    <LinearLayout
+        android:id="@+id/navHome"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:gravity="center"
+        android:orientation="vertical"
+        android:clickable="true"
+        android:focusable="true">
+
+        <ImageView
+            android:id="@+id/iconHome"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:tint="@color/custom_nav_item_color"
+            android:src="@drawable/ic_home" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Home"
+            android:textSize="12sp"
+            android:textColor="@color/custom_nav_item_color" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/navPredictions"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:gravity="center"
+        android:orientation="vertical"
+        android:clickable="true"
+        android:focusable="true">
+
+        <ImageView
+            android:id="@+id/iconPredictions"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:tint="@color/custom_nav_item_color"
+            android:src="@drawable/ic_star" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Predictions"
+            android:textSize="12sp"
+            android:textColor="@color/custom_nav_item_color" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/navHistory"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:gravity="center"
+        android:orientation="vertical"
+        android:clickable="true"
+        android:focusable="true">
+
+        <ImageView
+            android:id="@+id/iconHistory"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:tint="@color/custom_nav_item_color"
+            android:src="@drawable/ic_history" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="History"
+            android:textSize="12sp"
+            android:textColor="@color/custom_nav_item_color" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/navStats"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:gravity="center"
+        android:orientation="vertical"
+        android:clickable="true"
+        android:focusable="true">
+
+        <ImageView
+            android:id="@+id/iconStats"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:tint="@color/custom_nav_item_color"
+            android:src="@drawable/ic_stats" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="My stat"
+            android:textSize="12sp"
+            android:textColor="@color/custom_nav_item_color" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/navBlog"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:gravity="center"
+        android:orientation="vertical"
+        android:clickable="true"
+        android:focusable="true">
+
+        <ImageView
+            android:id="@+id/iconBlog"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:tint="@color/custom_nav_item_color"
+            android:src="@drawable/ic_blog" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Blog"
+            android:textSize="12sp"
+            android:textColor="@color/custom_nav_item_color" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/navAchievements"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:gravity="center"
+        android:orientation="vertical"
+        android:clickable="true"
+        android:focusable="true">
+
+        <ImageView
+            android:id="@+id/iconAchievements"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:tint="@color/custom_nav_item_color"
+            android:src="@drawable/achievements_icon" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Achievements"
+            android:textSize="12sp"
+            android:textColor="@color/custom_nav_item_color" />
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -12,27 +12,18 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         app:defaultNavHost="true"
-        app:layout_constraintBottom_toTopOf="@+id/bottomNavigationView"
+        app:layout_constraintBottom_toTopOf="@+id/bottomNav"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:navGraph="@navigation/secondgraph" />
 
-    <com.google.android.material.bottomnavigation.BottomNavigationView
-        android:id="@+id/bottomNavigationView"
-        style="@style/NoItemBackgroundBottomNavigationView"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:background="#171717"
-        android:paddingTop="10dp"
-        app:itemBackground="@android:color/transparent"
-        app:itemIconTint="@color/nav_item_color"
-        app:itemTextColor="@color/nav_item_color"
-        app:labelVisibilityMode="labeled"
+    <include
+        android:id="@+id/bottomNav"
+        layout="@layout/custom_bottom_navigation"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:menu="@menu/bottom_nav_menu" />
+        app:layout_constraintStart_toStartOf="parent" />
 
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/secondgraph.xml
+++ b/app/src/main/res/navigation/secondgraph.xml
@@ -19,6 +19,12 @@
         android:name="be.buithg.etghaifgte.presentation.ui.fragments.main.StatsFragment"
         android:label="fragment_stats"
         tools:layout="@layout/fragment_stats" />
+
+    <fragment
+        android:id="@+id/achievementsFragment"
+        android:name="be.buithg.etghaifgte.presentation.ui.fragments.main.AchievementsFragment"
+        android:label="fragment_achievements"
+        tools:layout="@layout/fragment_achievements" />
     <fragment
         android:id="@+id/predictionsFragment"
         android:name="be.buithg.etghaifgte.presentation.ui.fragments.main.PredictionsFragment"


### PR DESCRIPTION
## Summary
- replace BottomNavigationView with custom layout to allow six items
- hook up custom navigation logic in HomeFragment
- add AchievementsFragment to navigation graph
- include achievements icon and color selector for highlighting

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a346acbe0832aafe18f3d08b951e0