### PR TITLE
Filter predictions by day in schedule

### DIFF
--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/MatchScheduleFragment.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/MatchScheduleFragment.kt
@@ -48,6 +48,10 @@ class MatchScheduleFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        // default selected day
+        selectedBtn = binding.btnToday
+        predictionsViewModel.setFilterDate(LocalDate.now())
+
         if (requireContext().isInternetAvailable()) {
             viewModel.loadMatches("80112a77-1b12-4356-94a5-806e6db2dc64")
         } else {
@@ -89,8 +93,6 @@ class MatchScheduleFragment : Fragment() {
             }
         }
 
-        // по умолчанию — Today выбран
-        selectedBtn = binding.btnToday
         updateSelection(binding.btnToday)
     }
     private fun updateSelection(selectedButton: MaterialButton) {
@@ -130,6 +132,7 @@ class MatchScheduleFragment : Fragment() {
             R.id.btnTomorrow -> LocalDate.now().plusDays(1)
             else -> LocalDate.now()
         }
+        predictionsViewModel.setFilterDate(selectedDate)
         val filtered = allMatches.filter {
             runCatching { LocalDate.parse(it.date) }.getOrNull() == selectedDate
         }


### PR DESCRIPTION
## Summary
- update `PredictionsViewModel` to support filtering counts by date
- apply selected date filter when toggling in `MatchScheduleFragment`

## Testing
- `./gradlew tasks --all`
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a3aae94e4832a8ba7341e66e8fb9a