### PR TITLE
Enable match detail navigation from history

### DIFF
--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/adapters/HistoryAdapter.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/adapters/HistoryAdapter.kt
@@ -9,7 +9,8 @@ import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
 class HistoryAdapter(
-    private val items: List<PredictionEntity>
+    private val items: List<PredictionEntity>,
+    private val onViewDetails: (PredictionEntity) -> Unit
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
     private companion object {
@@ -41,6 +42,10 @@ class HistoryAdapter(
             }
             binding.textPick.text = "Pick: ${item.pick} $result"
             binding.textResult.text = result
+
+            binding.btnViewDetails.setOnClickListener {
+                onViewDetails(item)
+            }
         }
     }
 

--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/PredictionHistoryFragment.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/PredictionHistoryFragment.kt
@@ -15,6 +15,8 @@ import androidx.core.view.isVisible
 import be.buithg.etghaifgte.data.local.entity.PredictionEntity
 import be.buithg.etghaifgte.presentation.ui.adapters.HistoryAdapter
 import be.buithg.etghaifgte.presentation.viewmodel.PredictionsViewModel
+import be.buithg.etghaifgte.domain.models.Data
+import be.buithg.etghaifgte.domain.models.TeamInfo
 import com.google.android.material.button.MaterialButton
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -100,7 +102,42 @@ class PredictionHistoryFragment : Fragment() {
             Filter.WINNER -> allPredictions.filter { getResult(it) == "Win" }
             Filter.LOST -> allPredictions.filter { getResult(it) == "Lose" }
         }
-        binding.predictionsHistoryRecyclerview.adapter = HistoryAdapter(list)
+        binding.predictionsHistoryRecyclerview.adapter = HistoryAdapter(list) { prediction ->
+            val match = prediction.toData()
+            val action = PredictionHistoryFragmentDirections.actionPredictionHistoryFragmentToMatchDetailFragment(match)
+            findNavController().navigate(action)
+        }
+    }
+
+    private fun PredictionEntity.toData(): Data {
+        val status = if (upcoming == 1) {
+            "Upcoming"
+        } else {
+            when (wonMatches) {
+                1 -> "$teamA won"
+                2 -> "$teamB won"
+                else -> "Draw"
+            }
+        }
+
+        return Data(
+            bbbEnabled = false,
+            date = dateTime.substringBefore("T"),
+            dateTimeGMT = dateTime,
+            fantasyEnabled = false,
+            hasSquad = false,
+            id = "",
+            matchEnded = upcoming == 0,
+            matchStarted = upcoming == 0,
+            matchType = "",
+            name = "$teamA - $teamB",
+            score = emptyList(),
+            series_id = "",
+            status = status,
+            teamInfo = listOf(TeamInfo(shortname = teamA, name = teamA), TeamInfo(shortname = teamB, name = teamB)),
+            teams = listOf(teamA, teamB),
+            venue = ""
+        )
     }
 
 }

--- a/app/src/main/res/navigation/secondgraph.xml
+++ b/app/src/main/res/navigation/secondgraph.xml
@@ -34,7 +34,11 @@
         android:id="@+id/predictionHistoryFragment"
         android:name="be.buithg.etghaifgte.presentation.ui.fragments.main.PredictionHistoryFragment"
         android:label="fragment_prediction_history"
-        tools:layout="@layout/fragment_prediction_history" />
+        tools:layout="@layout/fragment_prediction_history" >
+        <action
+            android:id="@+id/action_predictionHistoryFragment_to_matchDetailFragment"
+            app:destination="@id/matchDetailFragment" />
+    </fragment>
     <fragment
         android:id="@+id/blogFragment"
         android:name="be.buithg.etghaifgte.presentation.ui.fragments.main.BlogFragment"


### PR DESCRIPTION
## Summary
- hook up 'View Details' button in prediction history items
- convert PredictionEntity to Data and navigate to MatchDetailFragment
- add action from PredictionHistoryFragment to MatchDetailFragment

## Testing
- `./gradlew help`

------
https://chatgpt.com/codex/tasks/task_e_687a3c53bc44832a8f0eb7c28a5621a4