### PR TITLE
Improve level system logic

### DIFF
--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/AchievementsFragment.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/AchievementsFragment.kt
@@ -18,6 +18,7 @@ import be.buithg.etghaifgte.utils.Constants.ACHIEVEMENTS_COUNT_KEY
 import be.buithg.etghaifgte.utils.Constants.ACHIEVEMENT_FIRST_WIN_KEY
 import be.buithg.etghaifgte.utils.Constants.ACHIEVEMENT_STREAK_KEY
 import be.buithg.etghaifgte.utils.Constants.ACHIEVEMENT_TOURNAMENT_KEY
+import be.buithg.etghaifgte.utils.Constants.LEVEL_KEY
 import be.buithg.etghaifgte.utils.Constants.getSharedPreferences
 
 @AndroidEntryPoint
@@ -25,6 +26,29 @@ class AchievementsFragment : Fragment() {
 
     private lateinit var  binding: FragmentAchievementsBinding
     private val viewModel: PredictionsViewModel by viewModels()
+
+    private val levels = listOf("Level 1", "Level 2", "EXPERT")
+
+    private fun updateLevelUI(level: Int) {
+        val index = level.coerceIn(0, levels.lastIndex)
+        binding.tvLevel.text = levels[index]
+    }
+
+    private fun increaseLevel() {
+        val prefs = context?.getSharedPreferences() ?: return
+        var level = prefs.getInt(LEVEL_KEY, 0)
+        if (level < levels.lastIndex) {
+            level++
+            prefs.edit { putInt(LEVEL_KEY, level) }
+            updateLevelUI(level)
+        }
+    }
+
+    private fun canClaim(progress: Int, key: String): Boolean {
+        val prefs = context?.getSharedPreferences() ?: return false
+        val done = prefs.getBoolean(key, false)
+        return done && progress >= 100
+    }
 
     private fun isWin(item: PredictionEntity): Boolean {
         return when (item.wonMatches) {
@@ -53,6 +77,26 @@ class AchievementsFragment : Fragment() {
 
         binding.btnHelp.setOnClickListener {
             findNavController().navigate(R.id.tutorialFragment)
+        }
+
+        val prefs = context?.getSharedPreferences()
+        val level = prefs?.getInt(LEVEL_KEY, 0) ?: 0
+        updateLevelUI(level)
+
+        binding.btnClaimReward.setOnClickListener {
+            if (canClaim(binding.progressIndicator.progress, ACHIEVEMENT_STREAK_KEY)) {
+                increaseLevel()
+            }
+        }
+        binding.btnClaimReward2.setOnClickListener {
+            if (canClaim(binding.progressIndicator2.progress, ACHIEVEMENT_TOURNAMENT_KEY)) {
+                increaseLevel()
+            }
+        }
+        binding.btnClaimReward3.setOnClickListener {
+            if (canClaim(binding.progressIndicator3.progress, ACHIEVEMENT_FIRST_WIN_KEY)) {
+                increaseLevel()
+            }
         }
 
         viewModel.predictions.observe(viewLifecycleOwner) { list ->

--- a/app/src/main/java/be/buithg/etghaifgte/utils/Constants.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/utils/Constants.kt
@@ -17,6 +17,7 @@ object Constants {
     const val ACHIEVEMENT_STREAK_KEY = "achievement_streak"
     const val ACHIEVEMENT_TOURNAMENT_KEY = "achievement_tournament"
     const val ACHIEVEMENT_FIRST_WIN_KEY = "achievement_first_win"
+    const val LEVEL_KEY = "user_level"
     private const val SHARED_PREFERENCES_KEY = "example_sample_shared_preferences"
 
     fun Context.getSharedPreferences(): SharedPreferences {

--- a/app/src/main/res/layout/fragment_achievements.xml
+++ b/app/src/main/res/layout/fragment_achievements.xml
@@ -130,6 +130,7 @@
                                 android:orientation="vertical">
 
                                 <TextView
+                                    android:id="@+id/tvLevel"
                                     android:layout_width="wrap_content"
                                     android:layout_height="wrap_content"
                                     android:text="EXPERT"


### PR DESCRIPTION
## Summary
- ensure players can only claim reward after completing an achievement
- gate claim buttons behind achievement progress check

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f65324ef0832ab21b3269f7275aed