### PR TITLE
Handle offline schedule state

### DIFF
--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/MatchScheduleFragment.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/MatchScheduleFragment.kt
@@ -55,6 +55,8 @@ class MatchScheduleFragment : Fragment() {
             viewModel.loadMatches("80112a77-1b12-4356-94a5-806e6db2dc64")
         } else {
             Log.e("FFFF", "No Internet connection")
+            allMatches = emptyList()
+            filterAndDisplay(selectedBtn ?: binding.btnToday)
         }
 
         binding.btnHelp.setOnClickListener {
@@ -139,5 +141,7 @@ class MatchScheduleFragment : Fragment() {
             findNavController().navigate(action)
         }
         binding.recyclerMatcher.adapter = adapter
+        binding.emptyText.isVisible = filtered.isEmpty()
+        binding.recyclerMatcher.isVisible = filtered.isNotEmpty()
     }
 }

--- a/app/src/main/res/layout/fragment_match_schedule.xml
+++ b/app/src/main/res/layout/fragment_match_schedule.xml
@@ -323,6 +323,16 @@
                 tools:listitem="@layout/match_item"
                 android:layout_gravity="bottom"/>
 
+            <TextView
+                android:id="@+id/emptyText"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:text="No matches available"
+                android:textColor="#FFFFFF"
+                android:padding="16dp"
+                android:visibility="gone" />
+
         </LinearLayout>
 
     </FrameLayout>


### PR DESCRIPTION
## Summary
- handle when device is offline on schedule screen
- show empty schedule text if no matches are available

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f7fe31858832aa3f05bc735836806