### PR TITLE
Fix legend spacing

### DIFF
--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/StatsFragment.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/StatsFragment.kt
@@ -19,11 +19,12 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.Month
 import com.github.mikephil.charting.charts.LineChart
-import com.github.mikephil.charting.components.Legend
-import com.github.mikephil.charting.components.LegendEntry
 import com.github.mikephil.charting.components.XAxis
 import com.github.mikephil.charting.data.*
 import com.github.mikephil.charting.formatter.IndexAxisValueFormatter
+import android.widget.LinearLayout
+import android.widget.TextView
+import android.view.ViewGroup
 
 @AndroidEntryPoint
 class StatsFragment : Fragment(R.layout.fragment_stats) {
@@ -31,6 +32,21 @@ class StatsFragment : Fragment(R.layout.fragment_stats) {
     private var _binding: FragmentStatsBinding? = null
     private val binding get() = _binding!!
     private val viewModel: PredictionsViewModel by viewModels()
+
+    private fun setupLegend(entries: List<Pair<String, Int>>) {
+        val container = binding.legendContainer
+        container.removeAllViews()
+        val inflater = LayoutInflater.from(container.context)
+        entries.forEach { (label, color) ->
+            val item = inflater.inflate(R.layout.view_legend_item, container, false)
+            val dot = item.findViewById<View>(R.id.legendDot)
+            val text = item.findViewById<TextView>(R.id.legendText)
+            dot.backgroundTintList = android.content.res.ColorStateList.valueOf(color)
+            text.text = label
+            val params = LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f)
+            container.addView(item, params)
+        }
+    }
 
     private fun isWin(item: PredictionEntity): Boolean {
         return when (item.wonMatches) {
@@ -217,28 +233,15 @@ class StatsFragment : Fragment(R.layout.fragment_stats) {
         }
 
         chart.data = LineData(sets)
-        chart.legend.apply {
-            verticalAlignment   = Legend.LegendVerticalAlignment.BOTTOM
-            horizontalAlignment = Legend.LegendHorizontalAlignment.CENTER
-            orientation         = Legend.LegendOrientation.HORIZONTAL
-
-            form      = Legend.LegendForm.CIRCLE
-            formSize  = 8f
-            textColor = Color.parseColor("#CCCCCC")
-
-            xEntrySpace = 16f
-            yEntrySpace = 4f
-
-            setDrawInside(false)
-            isEnabled = true
-
-            setCustom(listOf(
-                LegendEntry("2021", Legend.LegendForm.CIRCLE, 8f, 2f, null, Color.parseColor("#007AFF")),
-                LegendEntry("2022", Legend.LegendForm.CIRCLE, 8f, 2f, null, Color.parseColor("#4CD964")),
-                LegendEntry("2023", Legend.LegendForm.CIRCLE, 8f, 2f, null, Color.parseColor("#FF9500")),
-                LegendEntry("2024", Legend.LegendForm.CIRCLE, 8f, 2f, null, Color.parseColor("#32D3F2"))
-            ))
-        }
+        chart.legend.isEnabled = false
+        setupLegend(
+            listOf(
+                "2021" to Color.parseColor("#007AFF"),
+                "2022" to Color.parseColor("#4CD964"),
+                "2023" to Color.parseColor("#FF9500"),
+                "2024" to Color.parseColor("#32D3F2")
+            )
+        )
 
 
         chart.invalidate()
@@ -317,30 +320,15 @@ class StatsFragment : Fragment(R.layout.fragment_stats) {
         }
 
         chart.data = LineData(sets)
-        chart.legend.apply {
-            verticalAlignment = Legend.LegendVerticalAlignment.BOTTOM
-            horizontalAlignment = Legend.LegendHorizontalAlignment.CENTER
-            orientation = Legend.LegendOrientation.HORIZONTAL
-
-            form = Legend.LegendForm.CIRCLE
-            formSize = 8f
-            textColor = Color.parseColor("#CCCCCC")
-
-            xEntrySpace = 16f
-            yEntrySpace = 4f
-
-            setDrawInside(false)
-            isEnabled = true
-
-            setCustom(
-                listOf(
-                    LegendEntry("2021", Legend.LegendForm.CIRCLE, 8f, 2f, null, Color.parseColor("#007AFF")),
-                    LegendEntry("2022", Legend.LegendForm.CIRCLE, 8f, 2f, null, Color.parseColor("#4CD964")),
-                    LegendEntry("2023", Legend.LegendForm.CIRCLE, 8f, 2f, null, Color.parseColor("#FF9500")),
-                    LegendEntry("2024", Legend.LegendForm.CIRCLE, 8f, 2f, null, Color.parseColor("#32D3F2"))
-                )
+        chart.legend.isEnabled = false
+        setupLegend(
+            listOf(
+                "2021" to Color.parseColor("#007AFF"),
+                "2022" to Color.parseColor("#4CD964"),
+                "2023" to Color.parseColor("#FF9500"),
+                "2024" to Color.parseColor("#32D3F2")
             )
-        }
+        )
 
         chart.invalidate()
     }

--- a/app/src/main/res/layout/fragment_stats.xml
+++ b/app/src/main/res/layout/fragment_stats.xml
@@ -360,6 +360,15 @@
                         android:layout_margin="16dp"/>
                 </com.google.android.material.card.MaterialCardView>
 
+                <LinearLayout
+                    android:id="@+id/legendContainer"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="16dp"
+                    android:layout_marginTop="4dp"
+                    android:gravity="center"
+                    android:orientation="horizontal" />
+
 
 
             </LinearLayout>

--- a/app/src/main/res/layout/view_legend_item.xml
+++ b/app/src/main/res/layout/view_legend_item.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:gravity="center_vertical">
+
+    <View
+        android:id="@+id/legendDot"
+        android:layout_width="8dp"
+        android:layout_height="8dp"
+        android:background="@drawable/oval_shape" />
+
+    <TextView
+        android:id="@+id/legendText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="6dp"
+        android:text="Label"
+        android:textColor="#FFFFFF"
+        android:textSize="12sp" />
+</LinearLayout>


### PR DESCRIPTION
## Summary
- disable default MPAndroidChart legend and build a custom one
- add `legendContainer` for the new legend
- create small layout for legend items

## Testing
- `./gradlew test --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f9473a840832abcda78273a346768