### PR TITLE
Fix: Hide forecast button when viewing history

### DIFF
--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/MatchDetailFragment.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/MatchDetailFragment.kt
@@ -80,6 +80,9 @@ class MatchDetailFragment : Fragment() {
         }
 
         val match = args.match
+        if (args.fromHistory) {
+            binding.btnMakeForecast.visibility = View.GONE
+        }
         bindMatch(match)
         val team1Key = match.teamInfo.getOrNull(0)?.shortname ?: match.teams.getOrNull(0) ?: ""
         val team2Key = match.teamInfo.getOrNull(1)?.shortname ?: match.teams.getOrNull(1) ?: ""

--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/MatchScheduleFragment.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/MatchScheduleFragment.kt
@@ -157,7 +157,8 @@ class MatchScheduleFragment : Fragment() {
         adapter = CricketAdapter(ArrayList(filtered)) { match ->
             val action =
                 MatchScheduleFragmentDirections.actionMatchScheduleFragmentToMatchDetailFragment(
-                    match
+                    match,
+                    false
                 )
             findNavController().navigate(action)
         }

--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/PredictionHistoryFragment.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/PredictionHistoryFragment.kt
@@ -104,7 +104,10 @@ class PredictionHistoryFragment : Fragment() {
         }
         binding.predictionsHistoryRecyclerview.adapter = HistoryAdapter(list) { prediction ->
             val match = prediction.toData()
-            val action = PredictionHistoryFragmentDirections.actionPredictionHistoryFragmentToMatchDetailFragment(match)
+            val action = PredictionHistoryFragmentDirections.actionPredictionHistoryFragmentToMatchDetailFragment(
+                match,
+                true
+            )
             findNavController().navigate(action)
         }
     }

--- a/app/src/main/res/navigation/secondgraph.xml
+++ b/app/src/main/res/navigation/secondgraph.xml
@@ -71,6 +71,10 @@
         <argument
             android:name="match"
             app:argType="be.buithg.etghaifgte.domain.models.Data" />
+        <argument
+            android:name="fromHistory"
+            app:argType="boolean"
+            android:defaultValue="false" />
         <action
             android:id="@+id/action_matchDetailFragment_to_noteFragment"
             app:destination="@id/noteFragment" />


### PR DESCRIPTION
## Summary
- add a `fromHistory` argument in the navigation graph
- hide the forecast button when opened from history
- pass the proper argument when navigating to `MatchDetailFragment`

## Testing
- `./gradlew testDebugUnitTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68815446ef84832ab05139e0ca3540df