### PR TITLE
Fix upcoming prediction handling

### DIFF
--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/adapters/HistoryAdapter.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/adapters/HistoryAdapter.kt
@@ -31,7 +31,13 @@ class HistoryAdapter(
 
             binding.textTeams.text = "${item.teamA} - ${item.teamB}"
 
-            val result = if (item.upcoming == 1) {
+            val isUpcoming = if (item.upcoming == 1) {
+                true
+            } else {
+                dt?.isAfter(LocalDateTime.now()) ?: false
+            }
+
+            val result = if (isUpcoming) {
                 "Upcoming"
             } else {
                 when (item.wonMatches) {

--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/adapters/PredictionsAdapter.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/adapters/PredictionsAdapter.kt
@@ -27,15 +27,20 @@ class PredictionsAdapter(
 
         fun bind(item: PredictionEntity) {
             val dt = runCatching { LocalDateTime.parse(item.dateTime) }.getOrNull()
-
+            
             binding.textTime.text = dt?.format(timeFormatter) ?: item.dateTime
             binding.textDate.text = dt?.format(dateFormatter) ?: item.dateTime
 
             binding.textPrediction.text = item.pick // or "Pick: ${item.pick}"
 
             binding.textTeams.text = "${item.teamA} - ${item.teamB}"
+            val isUpcoming = if (item.upcoming == 1) {
+                true
+            } else {
+                dt?.isAfter(LocalDateTime.now()) ?: false
+            }
 
-            if (item.upcoming == 1) {
+            if (isUpcoming) {
                 binding.textPrediction.text = "Upcoming"
                 binding.imageResult.setImageResource(be.buithg.etghaifgte.R.drawable.icon_upcoming)
             } else {

--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/PredictionHistoryFragment.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/PredictionHistoryFragment.kt
@@ -18,6 +18,7 @@ import be.buithg.etghaifgte.presentation.viewmodel.PredictionsViewModel
 import be.buithg.etghaifgte.domain.models.Data
 import be.buithg.etghaifgte.domain.models.TeamInfo
 import com.google.android.material.button.MaterialButton
+import java.time.LocalDateTime
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -88,8 +89,14 @@ class PredictionHistoryFragment : Fragment() {
         }
     }
 
+    private fun isUpcoming(item: PredictionEntity): Boolean {
+        if (item.upcoming == 1) return true
+        val dt = runCatching { LocalDateTime.parse(item.dateTime) }.getOrNull()
+        return dt?.isAfter(LocalDateTime.now()) ?: false
+    }
+
     private fun getResult(item: PredictionEntity): String {
-        if (item.upcoming == 1) return "матч еще не начался"
+        if (isUpcoming(item)) return "матч еще не начался"
         return when (item.wonMatches) {
             1 -> if (item.pick == item.teamA) "Win" else "Lose"
             2 -> if (item.pick == item.teamB) "Win" else "Lose"
@@ -113,7 +120,8 @@ class PredictionHistoryFragment : Fragment() {
     }
 
     private fun PredictionEntity.toData(): Data {
-        val status = if (upcoming == 1) {
+        val upcomingFlag = isUpcoming(this)
+        val status = if (upcomingFlag) {
             "Upcoming"
         } else {
             when (wonMatches) {
@@ -130,8 +138,8 @@ class PredictionHistoryFragment : Fragment() {
             fantasyEnabled = false,
             hasSquad = false,
             id = "",
-            matchEnded = upcoming == 0,
-            matchStarted = upcoming == 0,
+            matchEnded = !upcomingFlag,
+            matchStarted = !upcomingFlag,
             matchType = matchType,
 
             name = "$teamA - $teamB",


### PR DESCRIPTION
## Summary
- handle upcoming matches by comparing the match date with current time
- show upcoming status in prediction lists
- compute counts using the new upcoming check

## Testing
- `./gradlew test --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688247a94d5c832ab1c7a42783c6730f