### PR TITLE
Add toast for level up in AchievementsFragment

### DIFF
--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/AchievementsFragment.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/AchievementsFragment.kt
@@ -47,6 +47,10 @@ class AchievementsFragment : Fragment() {
             updateLevelUI(level)
         }
     }
+
+    private fun showLevelUpMessage() {
+        Toast.makeText(context, "You have reached a new level.", Toast.LENGTH_SHORT).show()
+    }
     private fun canClaim(progress: Int, completedKey: String, claimedKey: String): Boolean {
         val prefs = context?.getSharedPreferences() ?: return false
         val completed = prefs.getBoolean(completedKey, false)
@@ -105,6 +109,7 @@ class AchievementsFragment : Fragment() {
                     ACHIEVEMENT_STREAK_KEY,
                     ACHIEVEMENT_STREAK_CLAIMED_KEY)) {
                 increaseLevel()
+                showLevelUpMessage()
                 prefs.edit {
                     putBoolean(ACHIEVEMENT_STREAK_CLAIMED_KEY, true)
                 }
@@ -124,6 +129,7 @@ class AchievementsFragment : Fragment() {
                     ACHIEVEMENT_TOURNAMENT_KEY,
                     ACHIEVEMENT_TOURNAMENT_CLAIMED_KEY)) {
                 increaseLevel()
+                showLevelUpMessage()
                 prefs.edit {
                     putBoolean(ACHIEVEMENT_TOURNAMENT_CLAIMED_KEY, true)
                 }
@@ -143,6 +149,7 @@ class AchievementsFragment : Fragment() {
                     ACHIEVEMENT_FIRST_WIN_KEY,
                     ACHIEVEMENT_FIRSTWIN_CLAIMED_KEY)) {
                 increaseLevel()
+                showLevelUpMessage()
                 prefs.edit {
                     putBoolean(ACHIEVEMENT_FIRSTWIN_CLAIMED_KEY, true)
                 }


### PR DESCRIPTION
## Summary
- show a toast saying "You have reached a new level." when the player successfully claims a reward in `AchievementsFragment`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68825a264d14832abf98152bb339764f