### PR TITLE
Fix null crashes in match details

### DIFF
--- a/app/src/main/java/be/buithg/etghaifgte/domain/models/Data.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/domain/models/Data.kt
@@ -4,20 +4,20 @@ import java.io.Serializable
 
 data class Data(
     val bbbEnabled: Boolean,
-    val date: String,
-    val dateTimeGMT: String,
+    val date: String?,
+    val dateTimeGMT: String?,
     val fantasyEnabled: Boolean,
     val hasSquad: Boolean,
-    val id: String,
+    val id: String?,
     val matchEnded: Boolean,
     val matchStarted: Boolean,
-    val matchType: String,
-    val name: String,
-    val score: List<Score>,
-    val series_id: String,
-    val status: String,
-    val teamInfo: List<TeamInfo>,
-    val teams: List<String>,
-    val venue: String
+    val matchType: String?,
+    val name: String?,
+    val score: List<Score>?,
+    val series_id: String?,
+    val status: String?,
+    val teamInfo: List<TeamInfo>?,
+    val teams: List<String>?,
+    val venue: String?
 ): Serializable
 

--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/adapters/CricketAdapter.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/adapters/CricketAdapter.kt
@@ -59,26 +59,26 @@ class CricketAdapter(
 
         fun bind(item: Data, position: Int) {
             // 1) Время
-            val ldt = LocalDateTime.parse(item.dateTimeGMT)
+            val ldt = runCatching { LocalDateTime.parse(item.dateTimeGMT ?: "") }.getOrNull()
             val timeFormatter = DateTimeFormatter.ofPattern("HH:mm")
-            binding.tvTime.text = ldt.format(timeFormatter)
+            binding.tvTime.text = ldt?.format(timeFormatter) ?: "-"
 
             // 2) Статус
-            val statusText = if (!item.matchEnded) "Upcoming" else item.status
+            val statusText = if (!item.matchEnded) "Upcoming" else item.status ?: "-"
             binding.tvStatus.text = statusText.truncate(MAX_STATUS_LEN)
 
             // 3) Лига
-            val country = item.teamInfo.getOrNull(0)?.name
-                ?: item.teams.getOrNull(0).orEmpty()
+            val country = item.teamInfo?.getOrNull(0)?.name
+                ?: item.teams?.getOrNull(0).orEmpty()
             binding.tvLeague.text = country
             val color = Color.parseColor(leagueColors[position % leagueColors.size])
             binding.tvLeague.backgroundTintList = ColorStateList.valueOf(color)
 
             // 4) Описание матча (один TextView вместо двух)
-            val rawTeam1 = item.teamInfo.getOrNull(0)?.shortname
-                ?: item.teams.getOrNull(0).orEmpty()
-            val rawTeam2 = item.teamInfo.getOrNull(1)?.shortname
-                ?: item.teams.getOrNull(1).orEmpty()
+            val rawTeam1 = item.teamInfo?.getOrNull(0)?.shortname
+                ?: item.teams?.getOrNull(0).orEmpty()
+            val rawTeam2 = item.teamInfo?.getOrNull(1)?.shortname
+                ?: item.teams?.getOrNull(1).orEmpty()
 
             val t1 = rawTeam1.truncate(MAX_TEAM_LEN)
             val t2 = rawTeam2.truncate(MAX_TEAM_LEN)

--- a/app/src/main/java/be/buithg/etghaifgte/presentation/viewmodel/PredictionsViewModel.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/viewmodel/PredictionsViewModel.kt
@@ -39,17 +39,18 @@ class PredictionsViewModel @Inject constructor(
     private val apiKey = "1c5944c7-5c88-4b8c-80f3-c88f198ed725"
 
     private fun winnerTeam(match: Data): Int {
-        val team1 = match.teamInfo.getOrNull(0)?.shortname ?: match.teams.getOrNull(0) ?: ""
-        val team2 = match.teamInfo.getOrNull(1)?.shortname ?: match.teams.getOrNull(1) ?: ""
+        val team1 = match.teamInfo?.getOrNull(0)?.shortname ?: match.teams?.getOrNull(0) ?: ""
+        val team2 = match.teamInfo?.getOrNull(1)?.shortname ?: match.teams?.getOrNull(1) ?: ""
 
-        if (match.score.size >= 2) {
-            val score1 = match.score[0].r
-            val score2 = match.score[1].r
+        val scores = match.score ?: emptyList()
+        if (scores.size >= 2) {
+            val score1 = scores[0].r
+            val score2 = scores[1].r
             if (score1 > score2) return 1
             if (score2 > score1) return 2
         }
 
-        val status = match.status.lowercase()
+        val status = match.status?.lowercase() ?: ""
         return when {
             status.contains(team1.lowercase()) -> 1
             status.contains(team2.lowercase()) -> 2


### PR DESCRIPTION
## Summary
- allow nullable fields in `Data` model
- handle missing info in `CricketAdapter`
- safely bind data in `MatchDetailFragment`
- update `PredictionsViewModel` to avoid null crashes

## Testing
- `./gradlew test --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887486cf6a8832aa114553cd36ca7ef