### PR TITLE
Integrate ESPN scoreboard API

### DIFF
--- a/app/src/main/java/be/buithg/etghaifgte/data/remote/ApiInterface.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/data/remote/ApiInterface.kt
@@ -1,13 +1,18 @@
 package be.buithg.etghaifgte.data.remote
 
-import be.buithg.etghaifgte.domain.models.CricketData
+import be.buithg.etghaifgte.domain.models.ScoreboardResponse
+import retrofit2.http.Path
 import retrofit2.http.GET
 import retrofit2.http.Query
 
 interface ApiInterface {
 
-    @GET("matches")
-    suspend fun getLiveScore(@Query("apikey") apikey :String) : CricketData
-
+    @GET("apis/site/v2/sports/{sport}/{league}/scoreboard")
+    suspend fun getScoreboard(
+        @Path("sport") sport: String,
+        @Path("league") league: String,
+        @Query("dates") dates: String? = null,
+        @Query("limit") limit: Int = 100
+    ): ScoreboardResponse
 
 }

--- a/app/src/main/java/be/buithg/etghaifgte/data/repository/MatchRepositoryImpl.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/data/repository/MatchRepositoryImpl.kt
@@ -1,16 +1,21 @@
 package be.buithg.etghaifgte.data.repository
 
 import be.buithg.etghaifgte.data.remote.ApiInterface
-import be.buithg.etghaifgte.domain.models.Data
+import be.buithg.etghaifgte.domain.models.Match
+import be.buithg.etghaifgte.domain.models.toMatches
 import be.buithg.etghaifgte.domain.repository.MatchRepository
 import javax.inject.Inject
 
 class MatchRepositoryImpl @Inject constructor(
     private val api: ApiInterface
 ) : MatchRepository {
-    override suspend fun getCurrentMatches(apiKey: String): List<Data> {
-        return api.getLiveScore(apiKey).data ?: emptyList()
+
+    override suspend fun getScoreboard(
+        sport: String,
+        league: String,
+        date: String?,
+        limit: Int
+    ): List<Match> {
+        return api.getScoreboard(sport, league, date, limit).toMatches()
     }
-
 }
-

--- a/app/src/main/java/be/buithg/etghaifgte/di/NetworkModule.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/di/NetworkModule.kt
@@ -5,6 +5,8 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import javax.inject.Singleton
@@ -15,9 +17,26 @@ object NetworkModule {
 
     @Provides
     @Singleton
-    fun provideRetrofit(): Retrofit =
+    fun provideLoggingInterceptor(): HttpLoggingInterceptor =
+        HttpLoggingInterceptor().apply {
+            level = HttpLoggingInterceptor.Level.BODY
+        }
+
+    @Provides
+    @Singleton
+    fun provideOkHttpClient(
+        loggingInterceptor: HttpLoggingInterceptor
+    ): OkHttpClient =
+        OkHttpClient.Builder()
+            .addInterceptor(loggingInterceptor)
+            .build()
+
+    @Provides
+    @Singleton
+    fun provideRetrofit(client: OkHttpClient): Retrofit =
         Retrofit.Builder()
-            .baseUrl("https://api.cricapi.com/v1/")
+            .baseUrl("https://site.api.espn.com/")
+            .client(client)
             .addConverterFactory(GsonConverterFactory.create())
             .build()
 

--- a/app/src/main/java/be/buithg/etghaifgte/domain/models/Match.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/domain/models/Match.kt
@@ -1,0 +1,21 @@
+package be.buithg.etghaifgte.domain.models
+
+import java.io.Serializable
+
+// Simplified match representation used in the app
+
+data class Match(
+    val date: String?,
+    val dateTimeGMT: String?,
+    val status: String?,
+    val matchType: String?,
+    val league: String?,
+    val venue: String?,
+    val city: String?,
+    val country: String?,
+    val teamA: String?,
+    val teamB: String?,
+    val scoreA: Int?,
+    val scoreB: Int?,
+    val matchEnded: Boolean
+) : Serializable

--- a/app/src/main/java/be/buithg/etghaifgte/domain/models/ScoreboardMapper.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/domain/models/ScoreboardMapper.kt
@@ -1,0 +1,28 @@
+package be.buithg.etghaifgte.domain.models
+
+// Helper to convert API response to domain model
+
+fun ScoreboardResponse.toMatches(): List<Match> {
+    val leagueAbbr = leagues?.firstOrNull()?.abbreviation
+    return events.orEmpty().map { event ->
+        val comp = event.competitions?.firstOrNull()
+        val venue = comp?.venue
+        val home = comp?.competitors?.find { it.homeAway == "home" }
+        val away = comp?.competitors?.find { it.homeAway == "away" }
+        Match(
+            date = event.date?.substringBefore("T"),
+            dateTimeGMT = comp?.startDate,
+            status = comp?.status?.type?.description,
+            matchType = event.shortName,
+            league = leagueAbbr,
+            venue = venue?.fullName,
+            city = venue?.address?.city,
+            country = venue?.address?.country,
+            teamA = home?.team?.displayName,
+            teamB = away?.team?.displayName,
+            scoreA = home?.score?.toIntOrNull(),
+            scoreB = away?.score?.toIntOrNull(),
+            matchEnded = comp?.status?.type?.completed ?: false
+        )
+    }
+}

--- a/app/src/main/java/be/buithg/etghaifgte/domain/models/ScoreboardModels.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/domain/models/ScoreboardModels.kt
@@ -1,0 +1,62 @@
+package be.buithg.etghaifgte.domain.models
+
+import java.io.Serializable
+
+// Response from ESPN scoreboard endpoint
+// Only necessary fields are declared for mapping to the app domain models
+
+data class ScoreboardResponse(
+    val leagues: List<League>?,
+    val events: List<Event>?
+) : Serializable
+
+data class League(
+    val abbreviation: String?
+) : Serializable
+
+data class Event(
+    val id: String?,
+    val date: String?,
+    val name: String?,
+    val shortName: String?,
+    val competitions: List<Competition>?,
+    val status: Status?
+) : Serializable
+
+data class Competition(
+    val startDate: String?,
+    val competitors: List<Competitor>?,
+    val venue: Venue?,
+    val status: Status?
+) : Serializable
+
+data class Venue(
+    val fullName: String?,
+    val address: Address?
+) : Serializable
+
+data class Address(
+    val city: String?,
+    val country: String?
+) : Serializable
+
+data class Competitor(
+    val homeAway: String?,
+    val score: String?,
+    val team: Team?
+) : Serializable
+
+data class Team(
+    val displayName: String?,
+    val shortDisplayName: String?
+) : Serializable
+
+data class Status(
+    val type: StatusType?
+) : Serializable
+
+data class StatusType(
+    val description: String?,
+    val state: String?,
+    val completed: Boolean?
+) : Serializable

--- a/app/src/main/java/be/buithg/etghaifgte/domain/repository/MatchRepository.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/domain/repository/MatchRepository.kt
@@ -1,8 +1,13 @@
 package be.buithg.etghaifgte.domain.repository
 
-import be.buithg.etghaifgte.domain.models.Data
+import be.buithg.etghaifgte.domain.models.Match
 
 interface MatchRepository {
-    suspend fun getCurrentMatches(apiKey: String): List<Data>
+    suspend fun getScoreboard(
+        sport: String,
+        league: String,
+        date: String? = null,
+        limit: Int = 100
+    ): List<Match>
 }
 

--- a/app/src/main/java/be/buithg/etghaifgte/domain/usecase/GetCurrentMatchesUseCase.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/domain/usecase/GetCurrentMatchesUseCase.kt
@@ -1,14 +1,19 @@
 package be.buithg.etghaifgte.domain.usecase
 
-import be.buithg.etghaifgte.domain.models.Data
+import be.buithg.etghaifgte.domain.models.Match
 import be.buithg.etghaifgte.domain.repository.MatchRepository
 import javax.inject.Inject
 
 class GetCurrentMatchesUseCase @Inject constructor(
     private val repository: MatchRepository
 ) {
-    suspend operator fun invoke(apiKey: String): List<Data> {
-        return repository.getCurrentMatches(apiKey)
+    suspend operator fun invoke(
+        sport: String,
+        league: String,
+        date: String? = null,
+        limit: Int = 100
+    ): List<Match> {
+        return repository.getScoreboard(sport, league, date, limit)
     }
 }
 

--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/adapters/CricketAdapter.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/adapters/CricketAdapter.kt
@@ -3,7 +3,7 @@ package be.buithg.etghaifgte.presentation.ui.adapters
 import android.graphics.Color
 import android.content.res.ColorStateList
 import be.buithg.etghaifgte.databinding.MatchItemBinding
-import be.buithg.etghaifgte.domain.models.Data
+import be.buithg.etghaifgte.domain.models.Match
 
 
 import android.view.LayoutInflater
@@ -13,8 +13,8 @@ import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
 class CricketAdapter(
-    private val items: ArrayList<Data>,
-    private val onItemClick: (Data) -> Unit
+    private val items: ArrayList<Match>,
+    private val onItemClick: (Match) -> Unit
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
     private companion object {
@@ -57,7 +57,7 @@ class CricketAdapter(
         private val binding: MatchItemBinding
     ) : RecyclerView.ViewHolder(binding.root) {
 
-        fun bind(item: Data, position: Int) {
+        fun bind(item: Match, position: Int) {
             // 1) Время
             val ldt = runCatching { LocalDateTime.parse(item.dateTimeGMT ?: "") }.getOrNull()
             val timeFormatter = DateTimeFormatter.ofPattern("HH:mm")
@@ -68,17 +68,13 @@ class CricketAdapter(
             binding.tvStatus.text = statusText.truncate(MAX_STATUS_LEN)
 
             // 3) Лига
-            val country = item.teamInfo?.getOrNull(0)?.name
-                ?: item.teams?.getOrNull(0).orEmpty()
-            binding.tvLeague.text = country
+            binding.tvLeague.text = item.league ?: ""
             val color = Color.parseColor(leagueColors[position % leagueColors.size])
             binding.tvLeague.backgroundTintList = ColorStateList.valueOf(color)
 
             // 4) Описание матча (один TextView вместо двух)
-            val rawTeam1 = item.teamInfo?.getOrNull(0)?.shortname
-                ?: item.teams?.getOrNull(0).orEmpty()
-            val rawTeam2 = item.teamInfo?.getOrNull(1)?.shortname
-                ?: item.teams?.getOrNull(1).orEmpty()
+            val rawTeam1 = item.teamA.orEmpty()
+            val rawTeam2 = item.teamB.orEmpty()
 
             val t1 = rawTeam1.truncate(MAX_TEAM_LEN)
             val t2 = rawTeam2.truncate(MAX_TEAM_LEN)

--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/MatchScheduleFragment.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/MatchScheduleFragment.kt
@@ -14,7 +14,7 @@ import android.view.View
 import android.view.ViewGroup
 import be.buithg.etghaifgte.R
 import be.buithg.etghaifgte.databinding.FragmentMatchScheduleBinding
-import be.buithg.etghaifgte.domain.models.Data
+import be.buithg.etghaifgte.domain.models.Match
 import be.buithg.etghaifgte.presentation.ui.adapters.CricketAdapter
 import be.buithg.etghaifgte.presentation.viewmodel.MatchScheduleViewModel
 
@@ -39,7 +39,7 @@ class MatchScheduleFragment : Fragment() {
     private val predictionsViewModel: PredictionsViewModel by viewModels()
     private lateinit var buttons: List<MaterialButton>
     private lateinit var adapter: CricketAdapter
-    private var allMatches: List<Data> = emptyList()
+    private var allMatches: List<Match> = emptyList()
     private var selectedBtn: MaterialButton? = null
     private lateinit var connectivityManager: ConnectivityManager
     private var networkCallback: ConnectivityManager.NetworkCallback? = null
@@ -63,14 +63,14 @@ class MatchScheduleFragment : Fragment() {
         networkCallback = object : ConnectivityManager.NetworkCallback() {
             override fun onAvailable(network: Network) {
                 viewLifecycleOwner.lifecycleScope.launch {
-                    viewModel.loadMatches("9f341900-3c1d-4a56-ab0e-b6f93b82b678")
+                    viewModel.loadMatches("soccer", "eng.1")
                 }
             }
         }
         connectivityManager.registerDefaultNetworkCallback(networkCallback!!)
 
         if (requireContext().isInternetAvailable()) {
-            viewModel.loadMatches("9f341900-3c1d-4a56-ab0e-b6f93b82b678")
+            viewModel.loadMatches("soccer", "eng.1")
         } else {
             Log.e("FFFF", "No Internet connection")
             allMatches = emptyList()
@@ -84,7 +84,7 @@ class MatchScheduleFragment : Fragment() {
         binding.btnRetry.setOnClickListener {
             if (requireContext().isInternetAvailable()) {
                 viewLifecycleOwner.lifecycleScope.launch {
-                    viewModel.loadMatches("9f341900-3c1d-4a56-ab0e-b6f93b82b678")
+                    viewModel.loadMatches("soccer", "eng.1")
                 }
             } else {
                 Log.e("FFFF", "No Internet connection")
@@ -161,7 +161,7 @@ class MatchScheduleFragment : Fragment() {
         val filtered = allMatches.filter {
             runCatching { LocalDate.parse(it.date) }.getOrNull() == selectedDate
         }.take(10)
-        val upcomingCount = filtered.count { !it.matchStarted }
+        val upcomingCount = filtered.count { !it.matchEnded }
         binding.tvUpcomingCount.text = upcomingCount.toString().padStart(2, '0')
         adapter = CricketAdapter(ArrayList(filtered)) { match ->
             val action =

--- a/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/PredictionHistoryFragment.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/ui/fragments/main/PredictionHistoryFragment.kt
@@ -15,7 +15,7 @@ import androidx.core.view.isVisible
 import be.buithg.etghaifgte.data.local.entity.PredictionEntity
 import be.buithg.etghaifgte.presentation.ui.adapters.HistoryAdapter
 import be.buithg.etghaifgte.presentation.viewmodel.PredictionsViewModel
-import be.buithg.etghaifgte.domain.models.Data
+import be.buithg.etghaifgte.domain.models.Match
 import be.buithg.etghaifgte.domain.models.TeamInfo
 import com.google.android.material.button.MaterialButton
 import java.time.LocalDateTime
@@ -110,7 +110,7 @@ class PredictionHistoryFragment : Fragment() {
             Filter.LOST -> allPredictions.filter { getResult(it) == "Lose" }
         }
         binding.predictionsHistoryRecyclerview.adapter = HistoryAdapter(list) { prediction ->
-            val match = prediction.toData()
+            val match = prediction.toMatch()
             val action = PredictionHistoryFragmentDirections.actionPredictionHistoryFragmentToMatchDetailFragment(
                 match,
                 true
@@ -119,7 +119,7 @@ class PredictionHistoryFragment : Fragment() {
         }
     }
 
-    private fun PredictionEntity.toData(): Data {
+    private fun PredictionEntity.toMatch(): Match {
         val upcomingFlag = isUpcoming(this)
         val status = if (upcomingFlag) {
             "Upcoming"
@@ -131,25 +131,20 @@ class PredictionHistoryFragment : Fragment() {
             }
         }
 
-        return Data(
-            bbbEnabled = false,
+        return Match(
             date = dateTime.substringBefore("T"),
             dateTimeGMT = dateTime,
-            fantasyEnabled = false,
-            hasSquad = false,
-            id = "",
-            matchEnded = !upcomingFlag,
-            matchStarted = !upcomingFlag,
-            matchType = matchType,
-
-            name = "$teamA - $teamB",
-            score = emptyList(),
-            series_id = "",
             status = status,
-            teamInfo = listOf(TeamInfo(shortname = teamA, name = teamA), TeamInfo(shortname = teamB, name = teamB)),
-            teams = listOf(teamA, teamB),
-            venue = listOfNotNull(stadium.takeIf { it.isNotBlank() }, city.takeIf { it.isNotBlank() }).joinToString(", ")
-
+            matchType = matchType,
+            league = null,
+            venue = stadium,
+            city = city,
+            country = null,
+            teamA = teamA,
+            teamB = teamB,
+            scoreA = null,
+            scoreB = null,
+            matchEnded = !upcomingFlag
         )
     }
 

--- a/app/src/main/java/be/buithg/etghaifgte/presentation/viewmodel/MatchScheduleViewModel.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/viewmodel/MatchScheduleViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import be.buithg.etghaifgte.domain.models.Data
+import be.buithg.etghaifgte.domain.models.Match
 import be.buithg.etghaifgte.domain.usecase.GetCurrentMatchesUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -15,12 +15,12 @@ class MatchScheduleViewModel @Inject constructor(
     private val getCurrentMatchesUseCase: GetCurrentMatchesUseCase
 ) : ViewModel() {
 
-    private val _matches = MutableLiveData<List<Data>>(emptyList())
-    val matches: LiveData<List<Data>> = _matches
+    private val _matches = MutableLiveData<List<Match>>(emptyList())
+    val matches: LiveData<List<Match>> = _matches
 
-    fun loadMatches(apiKey: String) {
+    fun loadMatches(sport: String, league: String, date: String? = null) {
         viewModelScope.launch {
-            runCatching { getCurrentMatchesUseCase(apiKey) }
+            runCatching { getCurrentMatchesUseCase(sport, league, date) }
                 .onSuccess { _matches.value = it }
                 .onFailure { _matches.value = emptyList() }
         }

--- a/app/src/main/java/be/buithg/etghaifgte/presentation/viewmodel/PredictionsViewModel.kt
+++ b/app/src/main/java/be/buithg/etghaifgte/presentation/viewmodel/PredictionsViewModel.kt
@@ -8,7 +8,7 @@ import be.buithg.etghaifgte.data.local.entity.PredictionEntity
 import be.buithg.etghaifgte.domain.usecase.AddPredictionUseCase
 import be.buithg.etghaifgte.domain.usecase.GetPredictionsUseCase
 import be.buithg.etghaifgte.domain.usecase.GetCurrentMatchesUseCase
-import be.buithg.etghaifgte.domain.models.Data
+import be.buithg.etghaifgte.domain.models.Match
 import dagger.hilt.android.lifecycle.HiltViewModel
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -36,25 +36,15 @@ class PredictionsViewModel @Inject constructor(
 
     private var filterDate: LocalDate? = null
 
-    private val apiKey = "1c5944c7-5c88-4b8c-80f3-c88f198ed725"
+    private val sport = "soccer"
+    private val league = "eng.1"
 
-    private fun winnerTeam(match: Data): Int {
-        val team1 = match.teamInfo?.getOrNull(0)?.shortname ?: match.teams?.getOrNull(0) ?: ""
-        val team2 = match.teamInfo?.getOrNull(1)?.shortname ?: match.teams?.getOrNull(1) ?: ""
-
-        val scores = match.score ?: emptyList()
-        if (scores.size >= 2) {
-            val score1 = scores[0].r
-            val score2 = scores[1].r
-            if (score1 > score2) return 1
-            if (score2 > score1) return 2
-        }
-
-        val status = match.status?.lowercase() ?: ""
+    private fun winnerTeam(match: Match): Int {
+        val scoreA = match.scoreA ?: 0
+        val scoreB = match.scoreB ?: 0
         return when {
-            status.contains(team1.lowercase()) -> 1
-            status.contains(team2.lowercase()) -> 2
-            status.contains("draw") -> 0
+            scoreA > scoreB -> 1
+            scoreB > scoreA -> 2
             else -> 0
         }
     }
@@ -110,7 +100,7 @@ class PredictionsViewModel @Inject constructor(
         val upcomingList = list.filter { isUpcoming(it) }
         if (upcomingList.isEmpty()) return
 
-        val matches = runCatching { getCurrentMatchesUseCase(apiKey) }.getOrNull() ?: return
+        val matches = runCatching { getCurrentMatchesUseCase(sport, league) }.getOrNull() ?: return
 
         upcomingList.forEach { prediction ->
             val match = matches.find { it.dateTimeGMT == prediction.dateTime }

--- a/app/src/main/res/navigation/secondgraph.xml
+++ b/app/src/main/res/navigation/secondgraph.xml
@@ -70,7 +70,7 @@
         tools:layout="@layout/fragment_match_detail" >
         <argument
             android:name="match"
-            app:argType="be.buithg.etghaifgte.domain.models.Data" />
+            app:argType="be.buithg.etghaifgte.domain.models.Match" />
         <argument
             android:name="fromHistory"
             app:argType="boolean"


### PR DESCRIPTION
## Summary
- add models for ESPN scoreboard
- add Retrofit call and update network module
- adapt repository and use cases for new endpoint
- update view models, fragments and adapter to use `Match`
- update navigation graph for new argument type

## Testing
- `./gradlew tasks --all`
- `./gradlew assembleDebug --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68888b426f20832aa31191cb22a88d1b